### PR TITLE
Enable specifying a log dir to load all data files from

### DIFF
--- a/tools_v2/tracelogger.js
+++ b/tools_v2/tracelogger.js
@@ -34,18 +34,23 @@ function request (files, callback) {
 }
 
 var url = GetUrlValue("data");
-if (/^[a-zA-Z0-9-.]*$/.test(url)) {
+if (/^\w+:\/\//.test(url))
+  throw new Error("Loading logs from absolute URLs is disallowed for security reasons.");
 
-  request([url], function (answer) {
-    var json = answer[0];
-    var pos = json.indexOf("=");
-    json = json.substr(pos+1);
-
-    var data = JSON.parse(json);
-    var page = new Page(data);
-    page.init()
-  });
+if (url[url.length-1] == '/') {
+  baseUrl += url;
+  url = 'tl-data.json';
 }
+
+request([url], function (answer) {
+  var json = answer[0];
+  var pos = json.indexOf("=");
+  json = json.substr(pos+1);
+
+  var data = JSON.parse(json);
+  var page = new Page(data);
+  page.init()
+});
 
 
 function percent(double) {

--- a/website/tracelogger.js
+++ b/website/tracelogger.js
@@ -34,18 +34,23 @@ function request (files, callback) {
 }
 
 var url = GetUrlValue("data");
-if (/^[a-zA-Z0-9-.]*$/.test(url)) {
+if (/^\w+:\/\//.test(url))
+  throw new Error("Loading logs from absolute URLs is disallowed for security reasons.");
 
-  request([url], function (answer) {
-    var json = answer[0];
-    var pos = json.indexOf("=");
-    json = json.substr(pos+1);
-
-    var data = JSON.parse(json);
-    var page = new Page(data);
-    page.init()
-  });
+if (url[url.length-1] == '/') {
+  baseUrl += url;
+  url = 'tl-data.json';
 }
+
+request([url], function (answer) {
+  var json = answer[0];
+  var pos = json.indexOf("=");
+  json = json.substr(pos+1);
+
+  var data = JSON.parse(json);
+  var page = new Page(data);
+  page.init()
+});
 
 
 function percent(double) {


### PR DESCRIPTION
Makes it possible to very easily deploy logs: just create a directory somewhere reachable on the server, copy the tl\* files from /tmp into that, and invoke tracelogger.html?log=my-logging-session-dir
