### PR TITLE
Improve testing for absolute URLs

### DIFF
--- a/tools_v2/tracelogger.js
+++ b/tools_v2/tracelogger.js
@@ -34,7 +34,7 @@ function request (files, callback) {
 }
 
 var url = GetUrlValue("data");
-if (/^\w+:\/\//.test(url))
+if (/^[\w\+\-\.]+:\/\//.test(url))
   throw new Error("Loading logs from absolute URLs is disallowed for security reasons.");
 
 var pos = url.lastIndexOf("/");


### PR DESCRIPTION
I suggest the change here; it covers all URL schemes better, including "view-source" and "web+example".
