### PR TITLE
Add a status line to show the length of drawQueue and futureDrawQueue.

### DIFF
--- a/tools_v2/tracelogger.html
+++ b/tools_v2/tracelogger.html
@@ -10,6 +10,8 @@
 <h1>Tracelogging</h1>
 
 <br />
+<div id='queueStatus'></div>
+<br />
 <canvas id="myCanvas" width="1500" height="400" style="border:1px solid #000000;position:relative"></canvas>
 
 <div id='backtrace'></div>

--- a/tools_v2/tracelogger.js
+++ b/tools_v2/tracelogger.js
@@ -175,6 +175,12 @@ DrawCanvas.prototype.draw = function() {
 }
 
 DrawCanvas.prototype.drawQueue = function() {
+  var queuestatus = document.getElementById("queueStatus");
+  if (queueStatus)
+    queuestatus.innerHTML = "Events in current drawQueue: "
+        + this.drawQueue.length
+        + " and in futureDrawQueue: "
+        + this.futureDrawQueue.length;
   var queue = this.drawQueue.splice(0,10000);
   for (var i=0; i<queue.length; i++) {
     this.drawItem(queue[i])


### PR DESCRIPTION
When processing large profiling data (1GB+) such as octane benchmark, Showing progress might be helpful.