### PR TITLE
Better handling for alternate data directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Tools V2
 **1. Creating a tracelogging graph:**
 
 - Checkout the tracelogger repo, or download just the content of the "website" folder
-- Run "python <path-to-website-dir>/server.py"
+- Run "python <path-to-website-dir>/server.py" from the directory containing the trace files (the current directory on Windows or /tmp elsewhere, unless $TLDIR was used)
 - Navigate with a browser to "http://localhost:8000/tracelogger.html"
 
 **2. reduce.py: Reducing a tracelogging graph:**

--- a/README.md
+++ b/README.md
@@ -19,11 +19,9 @@ Tools V2
 
 **1. Creating a tracelogging graph:**
 
-- Make a directory "tracelogging"
-- Download the content of the "website" folder and put it in the "tracelogging" folder
-- Copy the website/server.py file to the directory containing the trace files (/tmp on linux, the working directory in windows)
-- Run "python server.py" from that directory.
-- Navigate with a browser to "file:///PATH_TO/tracelogger.html"
+- Checkout the tracelogger repo, or download just the content of the "website" folder
+- Run "python <path-to-website-dir>/server.py"
+- Navigate with a browser to "http://localhost:8000/tracelogger.html"
 
 **2. reduce.py: Reducing a tracelogging graph:**
 

--- a/tools_v2/rename.py
+++ b/tools_v2/rename.py
@@ -54,7 +54,7 @@ if '/' in args.new_name:
 elif os.path.isdir(args.new_name):
     new_name = os.path.join(args.new_name, basename(jsfile))
 else:
-    new_name = os.path.join(dirname(jsfile), new_name)
+    new_name = os.path.join(dirname(jsfile), args.new_name)
 
 # Strip off the .json if we inherited one from the source.
 new_name, _ = os.path.splitext(new_name)

--- a/tools_v2/rename.py
+++ b/tools_v2/rename.py
@@ -1,46 +1,79 @@
 import argparse
-import subprocess
-import struct
 import json
 import shutil
 import os
+from os.path import abspath, basename, dirname
 
 argparser = argparse.ArgumentParser(description='Rename the files.')
-argparser.add_argument('js_file', help='the js file to parse')
-argparser.add_argument('new_name', help='the new js file name (and path), without the .json')
+argparser.add_argument('js_file',
+                       help='the js file to parse, or a directory containing tl-data.json')
+argparser.add_argument('new_name',
+                       help='the new js file name (and/or path), without the .json')
 args = argparser.parse_args()
 
-jsfile = args.js_file
-if jsfile[0] != "/":
-    jsfile = os.getcwd() + "/" + jsfile
+# Example:
+#  python rename.py tl-data.json myname
+#   - renames whatever tl-data.json points to in cwd to myname, re-points tl-data.json at it.
+#  python rename.py oldname.json newname
+#   - renames oldname to newname
+#  python rename.py /some/path /new/path
+#   - renames whatever /some/path/tl-data.json points to, to /new/path/<name>.json (the name
+#     is taken from the contents of /some/path/tl-data.json)
 
-datapwd = os.path.dirname(jsfile)
+jsfile = abspath(args.js_file)
+if os.path.isdir(jsfile):
+    jsfile = os.path.join(jsfile, "tl-data.json")
 
-new_name = args.new_name
-if new_name[0] != "/":
-    new_name = datapwd + "/" + new_name
+datapwd = dirname(jsfile)
 
 # Get the data information
-fp = open(jsfile, "r")
-data = json.load(fp)
-fp.close()
+with open(jsfile, "r") as fp:
+    data = json.load(fp)
 
-# Move jsfile
-shutil.move(jsfile, new_name+".json")
+# If the user gave the tl-data.json redirection file, load what it points to.
+redir_file = None
+if not isinstance(data, list):
+    redir_file = jsfile
+    print("Have redir file = " + redir_file)
+    jsfile = data
+    with open(jsfile, "r") as fp:
+        data = json.load(fp)
+
+# The new name is assumed to be in the jsfile's directory, unless it is given
+# as a directory itself, in which case it will be placed in the given directory
+# under the basename of the jsfile.
+if os.path.isdir(args.new_name):
+    new_name = os.path.join(args.new_name, basename(jsfile))
+    new_name, _ = os.path.splitext(new_name)
+else:
+    new_name = os.path.join(datapwd, args.new_name)
 
 for j in range(len(data)):
     tree = new_name+".tree."+str(j)+".tl"
     shutil.move(datapwd+"/"+data[j]["tree"], tree)
-    data[j]["tree"] = os.path.basename(tree)
+    data[j]["tree"] = basename(tree)
 
     events = new_name+".event."+str(j)+".tl"
     shutil.move(datapwd+"/"+data[j]["events"], events)
-    data[j]["events"] = os.path.basename(events)
+    data[j]["events"] = basename(events)
 
     ndict = new_name+".dict."+str(j)+".json"
     shutil.move(datapwd+"/"+data[j]["dict"], ndict)
-    data[j]["dict"] = os.path.basename(ndict)
+    data[j]["dict"] = basename(ndict)
 
-fp = open(new_name+".json", "w")
-json.dump(data, fp)
-fp.close()
+# Create new jsfile
+with open(new_name+".json", "w") as fp:
+    json.dump(data, fp)
+print("Wrote %s.json" % new_name)
+
+# Recreate the redirection file in the destination directory, if we used a
+# redirection file in the first place.
+if redir_file:
+    new_redir_file = os.path.join(dirname(new_name), "tl-data.json")
+    print("Writing " + new_redir_file)
+    with open(new_redir_file, "w") as fp:
+        fp.write("\"%s.json\"" % basename(new_name))
+    os.remove(redir_file)
+
+# If everything went ok, remove the original.
+os.remove(jsfile)

--- a/website/server.py
+++ b/website/server.py
@@ -1,11 +1,34 @@
 #! /usr/bin/env python2
 from SimpleHTTPServer import SimpleHTTPRequestHandler
 import BaseHTTPServer
+import os
+import sys
 
-class CORSRequestHandler (SimpleHTTPRequestHandler):
+datadir = os.getcwd()
+
+class TraceLoggerRequestHandler(SimpleHTTPRequestHandler):
+    # Add CORS header
     def end_headers (self):
         self.send_header('Access-Control-Allow-Origin', '*')
         SimpleHTTPRequestHandler.end_headers(self)
 
+    def translate_path(self, path):
+        '''Pass through most commands to the default translation, which resolves
+           relative to the current working directory. Directory listings and filenames
+           starting with "tl-" are resolved relative to the data directory.'''
+        cwdpath = SimpleHTTPRequestHandler.translate_path(self, path)
+        if cwdpath is None:
+            return cwdpath
+        if os.path.isdir(cwdpath) or os.path.basename(cwdpath).startswith("tl-"):
+            discard = len(os.getcwd()) + 1
+            return os.path.join(datadir, cwdpath[discard:])
+        return cwdpath
+
 if __name__ == '__main__':
-    BaseHTTPServer.test(CORSRequestHandler, BaseHTTPServer.HTTPServer)
+    # Interpret non-numeric first argument as a data directory.
+    if len(sys.argv) > 0:
+        try:
+            port = int(sys.argv[1])
+        except:
+            datadir = sys.argv.pop(1)
+    BaseHTTPServer.test(TraceLoggerRequestHandler, BaseHTTPServer.HTTPServer)

--- a/website/server.py
+++ b/website/server.py
@@ -4,7 +4,7 @@ import BaseHTTPServer
 import os
 import sys
 
-datadir = os.getcwd()
+datadir = None
 
 class TraceLoggerRequestHandler(SimpleHTTPRequestHandler):
     # Add CORS header
@@ -12,23 +12,35 @@ class TraceLoggerRequestHandler(SimpleHTTPRequestHandler):
         self.send_header('Access-Control-Allow-Origin', '*')
         SimpleHTTPRequestHandler.end_headers(self)
 
-    def translate_path(self, path):
+    def translate_path(self, url_path):
         '''Pass through most commands to the default translation, which resolves
-           relative to the current working directory. Directory listings and filenames
-           starting with "tl-" are resolved relative to the data directory.'''
-        cwdpath = SimpleHTTPRequestHandler.translate_path(self, path)
-        if cwdpath is None:
-            return cwdpath
-        if os.path.isdir(cwdpath) or os.path.basename(cwdpath).startswith("tl-"):
+           relative to the current working directory (containing the website/
+           files). Directory listings, *.json, and *.tl files are resolved
+           relative to the data directory.
+        '''
+        path = SimpleHTTPRequestHandler.translate_path(self, url_path)
+        if path is None:
+            return path
+        if os.path.isdir(path) or path.endswith(".json") or path.endswith(".tl"):
             discard = len(os.getcwd()) + 1
-            return os.path.join(datadir, cwdpath[discard:])
-        return cwdpath
+            return os.path.join(datadir, path[discard:])
+        return path
 
 if __name__ == '__main__':
     # Interpret non-numeric first argument as a data directory.
-    if len(sys.argv) > 0:
+    if len(sys.argv) > 1:
         try:
             port = int(sys.argv[1])
         except:
             datadir = sys.argv.pop(1)
+
+    if datadir is None:
+        datadir = os.getcwd()
+
+    # If not running from within the website/ directory, assume we are running
+    # from the data directory. cd to the website dir so we serve non-data files
+    # from there.
+    website_dir = os.path.realpath(os.path.dirname(__file__))
+    os.chdir(website_dir)
+
     BaseHTTPServer.test(TraceLoggerRequestHandler, BaseHTTPServer.HTTPServer)


### PR DESCRIPTION
I don't really like copying the website files on top of the data files. With the changes here, I can use $TLDIR to write the tracelog files to a directory, then from within that directory run .../tracelogger/website/server.py with no args. Then if you want to move things to a different directory, you can run rename.py to grab a dataset and rename it within its current directory, or move it to another directory.

I haven't actually tested all permutations. Please check if the previous invocations still work. I don't actually know how you normally use this. I believe the 2nd patch here should fix issue 19.